### PR TITLE
Fix Gentoo install

### DIFF
--- a/.github/workflows/ci-linux-gentoo.yml
+++ b/.github/workflows/ci-linux-gentoo.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: verify ci user has fish-shell
         run: |
-          test "$(tee </etc/passwd | grep ^ci: | grep -oP '[^:]+$')" = "$(which fish)"
+          test "$(tee </etc/passwd | grep ^ci: | grep -oP '[^:]+$')" = "$(readlink -f $(which fish))"
 
       - name: run tests
         run: sudo -iu ci fishtape /home/ci/.config/dotfiles/tests.fish

--- a/home/.chezmoiscripts/linux/gentoo/run_onchange_after_zza-install-cmake.sh
+++ b/home/.chezmoiscripts/linux/gentoo/run_onchange_after_zza-install-cmake.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-sudo emerge -n dev-util/cmake
+sudo emerge -n dev-build/cmake


### PR DESCRIPTION
Cmake was recategorized from dev-util to dev-build.

When setting the shell with `which fish`, the path is the canonical `/usr/bin/fish` but later when verifying the shell configuration with `which fish`, the path is the symlink `/usr/sbin/fish`. This is probably because of differences in $PATH during the two stages. Here I don't investigate the path, but rather use `readlink` to get the canonical path during verification.